### PR TITLE
Github Community Standards and additional Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -45,14 +45,10 @@ Others:
 
 ---
 
-## Fields
-**AgrO term**: 
-> ID and Label (ie. `[liming process](http://purl.obolibrary.org/obo/AGRO_00000112)`)
+## Issue forms upgrade
 
-**Suggested new label:**: 
+Used github issue forms template for new issues.
+References:
 
-**_Optional_**: 
-> Any additional information (like supporting evidence, PubMed ID, etc.)
-
-**Your nano-attribution (ORCID)**: 
-> If you don't have an ORCID, you can sign up for one [here](https://orcid.org/)
+- [Github Community - Issue Template](https://gh-community.github.io/issue-template-feedback/structured/)
+- [Github Docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates)

--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -45,10 +45,14 @@ Others:
 
 ---
 
-## Issue forms upgrade
+## Fields
+**AgrO term**: 
+> ID and Label (ie. `[liming process](http://purl.obolibrary.org/obo/AGRO_00000112)`)
 
-Used github issue forms template for new issues.
-References:
+**Suggested new label:**: 
 
-- [Github Community - Issue Template](https://gh-community.github.io/issue-template-feedback/structured/)
-- [Github Docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates)
+**_Optional_**: 
+> Any additional information (like supporting evidence, PubMed ID, etc.)
+
+**Your nano-attribution (ORCID)**: 
+> If you don't have an ORCID, you can sign up for one [here](https://orcid.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing via making requests on issue tracker
+
+## Before you write a new request, please consider the following: 
+
+- **Does the term already exist?** Before submitting suggestions for new ontology terms, check whether the term exist, either as a primary term or a synonym term. You can search using [OLS](http://www.ebi.ac.uk/ols/ontologies/{{ project.id }})
+
+## Guidelines for creating GitHub tickets with contributions to the ontology:
+
+1. **Write a detailed request:** Please be specific and include as many details as necessary, providing background information, and if possible, suggesting a solution. GOC editors will be better equipped to address your suggestions if you offer details regarding *'what is wrong'*, *'why'*, and *'how to fix it'*.
+
+2. **Provide examples and references:** Please include PMIDs for new term requests, and include also screenshots, or URLs illustrating the current ontology structure for other types of requests. 
+
+3. **For new term request:** Be sure to provide suggestions for label (name), definition, references, position in hierarchy, etc.
+
+4. **For updates to relationships:** Provide details of the current axioms, why you think they are wrong or not sufficient, and what exactly should be added or removed.
+
+# Contributing via making Pull Requests
+
+See [README-Editors](https://github.com/AgriculturalSemantics/agro/blob/master/src/ontology/README-editors.md) for additional info adding to the Ontology.


### PR DESCRIPTION
## Add contributors.md 
Following Github [Community Standards](https://github.com/AgriculturalSemantics/agro/community), adding contributors page, forked from ENVO for the time being. Need to update later.

